### PR TITLE
zed import module fix: find modules at directory of current script

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -129,10 +129,7 @@ impl LanguageServer for KotoServer {
             .await
             .get(&uri)
             .and_then(|info| info.get_definition_location(position))
-            .map(|definition| {
-                println!("Definition found: {definition:?}");
-                GotoDefinitionResponse::Scalar(definition.into())
-            });
+            .map(|definition| GotoDefinitionResponse::Scalar(definition.into()));
 
         if result.is_none() {
             self.client

--- a/src/source_info.rs
+++ b/src/source_info.rs
@@ -809,13 +809,19 @@ impl<'i> SourceInfoBuilder<'i> {
     }
 
     fn find_module(&self, name: &str) -> Option<Arc<Url>> {
-        let Ok(path) = koto_bytecode::find_module(name, None) else {
-            return None;
-        };
-        let Ok(url) = Url::from_file_path(path) else {
-            return None;
-        };
-        Some(Arc::new(url))
+        if let Ok(script_path_buf) = self.uri.to_file_path() {
+            // find modules at directory of current script
+            let script_path = Some(script_path_buf.parent().unwrap());
+            let Ok(path) = koto_bytecode::find_module(name, script_path) else {
+                return None;
+            };
+            let Ok(url) = Url::from_file_path(path) else {
+                return None;
+            };
+            Some(Arc::new(url))
+        } else {
+            None
+        }
     }
 
     fn push_frame(&mut self, locals_capacity: usize) {

--- a/src/source_info.rs
+++ b/src/source_info.rs
@@ -811,7 +811,7 @@ impl<'i> SourceInfoBuilder<'i> {
     fn find_module(&self, name: &str) -> Option<Arc<Url>> {
         if let Ok(script_path_buf) = self.uri.to_file_path() {
             // find modules at directory of current script
-            let script_path = Some(script_path_buf.parent().unwrap());
+            let script_path = script_path_buf.parent();
             let Ok(path) = koto_bytecode::find_module(name, script_path) else {
                 return None;
             };


### PR DESCRIPTION
With this fix, zed is able to find imported modules (assuming they are in the same directory as main script). If this should not be the default behaviour, then maybe we could pass optionally an argument to `koto-ls` and only then activate the changes from this PR.