### PR TITLE
Hover 

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -128,21 +128,25 @@ impl LanguageServer for KotoServer {
                     if location.uri.as_ref() == &uri {
                         info.get_definition_from_location(location)
                             .map(|definition| {
-                                let symbol = DocumentSymbol::from(&definition);
-                                format!("**{}**  \n{:?} reference", symbol.name, symbol.kind,)
+                                format!(
+                                    "**{}**  \n{:?} reference",
+                                    definition.id.as_str(),
+                                    definition.kind,
+                                )
                             })
                     } else {
                         lock_await.get(&location.uri).and_then(|info| {
-                            // TODO: needs module name list at source info to retrieve modulename
+                            // Module reference
                             if location.range.end.character == 0 && location.range.end.line == 0 {
-                                Some(format!("**{}**  \n{:?}", "modulename", "Module",))
+                                // TODO: proper way to handle module names
+                                None
                             } else {
                                 info.get_definition_from_location(location)
                                     .map(|definition| {
-                                        let symbol = DocumentSymbol::from(&definition);
                                         format!(
                                             "**{}**  \n{:?} reference (from module)",
-                                            symbol.name, symbol.kind,
+                                            definition.id.as_str(),
+                                            definition.kind,
                                         )
                                     })
                             }
@@ -152,8 +156,11 @@ impl LanguageServer for KotoServer {
                 .or_else(|| {
                     info.get_definition_from_position(position)
                         .map(|definition| {
-                            let symbol = DocumentSymbol::from(&definition);
-                            format!("**{}**  \n{:?} definition", symbol.name, symbol.kind,)
+                            format!(
+                                "**{}**  \n{:?} definition",
+                                definition.id.as_str(),
+                                definition.kind,
+                            )
                         })
                 })
         });

--- a/src/server.rs
+++ b/src/server.rs
@@ -134,14 +134,19 @@ impl LanguageServer for KotoServer {
                             })
                     } else {
                         lock_await.get(&location.uri).and_then(|info| {
-                            info.get_definition_from_location(location)
-                                .map(|definition| {
-                                    let symbol = DocumentSymbol::from(&definition);
-                                    format!(
-                                        "**{}**  \n{:?} reference (from module)",
-                                        symbol.name, symbol.kind,
-                                    )
-                                })
+                            // TODO: needs module name list at source info to retrieve modulename
+                            if location.range.end.character == 0 && location.range.end.line == 0 {
+                                Some(format!("**{}**  \n{:?}", "modulename", "Module",))
+                            } else {
+                                info.get_definition_from_location(location)
+                                    .map(|definition| {
+                                        let symbol = DocumentSymbol::from(&definition);
+                                        format!(
+                                            "**{}**  \n{:?} reference (from module)",
+                                            symbol.name, symbol.kind,
+                                        )
+                                    })
+                            }
                         })
                     }
                 })

--- a/src/server.rs
+++ b/src/server.rs
@@ -126,7 +126,7 @@ impl LanguageServer for KotoServer {
         let result = lock_await.get(&uri).and_then(|info| {
             info.get_referenced_definition_location(position)
                 .and_then(|location| {
-                    if location.uri.as_str() == uri.as_str() {
+                    if location.uri.as_ref() == &uri {
                         info.get_definition_from_location(location)
                             .map(|definition| {
                                 let symbol = DocumentSymbol::from(&definition);
@@ -185,26 +185,6 @@ impl LanguageServer for KotoServer {
                         })
                 })
         });
-
-        // let result = self
-        //     .source_info
-        //     .lock()
-        //     .await
-        //     .get(&uri)
-        //     .and_then(|info| info.get_definition(position))
-        //     .map(|(definition, is_ref)| {
-        //         let symbol = DocumentSymbol::from(&definition);
-        //         let text = format!(
-        //             "**{}**  \n{:?} {}",
-        //             symbol.name,
-        //             symbol.kind,
-        //             if is_ref { "reference" } else { "defintion" }
-        //         );
-        //         Hover {
-        //             contents: HoverContents::Scalar(MarkedString::String(text)),
-        //             range: None,
-        //         }
-        //     });
 
         if result.is_none() {
             self.client

--- a/src/source_info.rs
+++ b/src/source_info.rs
@@ -67,6 +67,29 @@ impl SourceInfo {
         SourceInfoBuilder::from_ast(&ast, uri, info_cache).build(error)
     }
 
+    pub fn get_definition(&self, position: Position) -> Option<(Definition, bool)> {
+        self.references
+            .binary_search_by(|reference| {
+                cmp_position_to_range(position, &reference.location.range)
+            })
+            .ok()
+            .map(|i| self.references[i].definition.range)
+            .and_then(|range| {
+                self.definitions
+                    .binary_search_by(|definition| cmp_ranges(&range, &definition.location.range))
+                    .ok()
+                    .map(|i| (self.definitions[i].clone(), true))
+            })
+            .or_else(|| {
+                self.definitions
+                    .binary_search_by(|definition| {
+                        cmp_position_to_range(position, &definition.location.range)
+                    })
+                    .ok()
+                    .map(|i| (self.definitions[i].clone(), false))
+            })
+    }
+
     pub fn get_definition_location(&self, position: Position) -> Option<Location> {
         self.references
             .binary_search_by(|reference| {
@@ -151,6 +174,16 @@ impl Iterator for FindReferencesIter<'_> {
             }
             None
         }
+    }
+}
+
+fn cmp_ranges(range1: &Range, range2: &Range) -> Ordering {
+    if range1.start < range2.start {
+        Ordering::Greater
+    } else if range1.end > range2.end {
+        Ordering::Less
+    } else {
+        Ordering::Equal
     }
 }
 

--- a/src/source_info.rs
+++ b/src/source_info.rs
@@ -72,7 +72,7 @@ impl SourceInfo {
 
     pub fn get_definition_from_location(&self, location: Location) -> Option<Definition> {
         self.definitions
-            .binary_search_by(|definition| cmp_ranges(&location.range, &definition.location.range))
+            .binary_search_by(|definition| definition.cmp_location(&location))
             .ok()
             .map(|i| self.definitions[i].clone())
     }
@@ -177,16 +177,6 @@ impl Iterator for FindReferencesIter<'_> {
     }
 }
 
-fn cmp_ranges(range1: &Range, range2: &Range) -> Ordering {
-    if range1.start < range2.start {
-        Ordering::Less
-    } else if range1.end > range2.end {
-        Ordering::Greater
-    } else {
-        Ordering::Equal
-    }
-}
-
 fn cmp_position_to_range(position: Position, range: &Range) -> Ordering {
     if position < range.start {
         Ordering::Greater
@@ -225,6 +215,16 @@ impl Definition {
             } else {
                 Some(children)
             },
+        }
+    }
+
+    fn cmp_location(&self, location: &Location) -> Ordering {
+        if self.location.range.start < location.range.start {
+            Ordering::Less
+        } else if self.location.range.end > location.range.end {
+            Ordering::Greater
+        } else {
+            Ordering::Equal
         }
     }
 }


### PR DESCRIPTION
Here comes my initial attempt at hover

Current features:
- hover over references (local and imported ones), diplays the symbol kind
- hover over definitions

partially implemented:
- hover over modules (to dislplay the actual name, I think we  need a modules list, similar to references or definitions)

not implemented yet:
- hover of keywords (that requires a keywords list, similar to references or definitions)
- hover over Rust API references (that is still at very early stage)
- display meanigful context, e.g. retrieved from source code comments