### PR TITLE
Upgraded tower_lsp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,28 +24,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
-name = "async-trait"
-version = "0.1.88"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "auto_impl"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12882f59de5360c748c4cbf569a042d5fb0eb515f7bea9c1f470b47f6ffbd73"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,12 +75,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23bdce1da528cadbac4654b5632bfcd8c6c63e25b1d42cea919a95958790b51d"
 
 [[package]]
-name = "dashmap"
-version = "5.5.3"
+name = "crossbeam-utils"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
  "cfg-if",
+ "crossbeam-utils",
  "hashbrown",
  "lock_api",
  "once_cell",
@@ -129,29 +114,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
-name = "form_urlencoded"
-version = "1.2.1"
+name = "fluent-uri"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
 dependencies = [
- "percent-encoding",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -250,145 +224,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "icu_collections"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
-
-[[package]]
-name = "icu_normalizer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
-
-[[package]]
-name = "icu_properties"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_locid_transform",
- "icu_properties_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
-
-[[package]]
-name = "icu_provider"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
- "writeable",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "idna"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
-dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
-]
-
-[[package]]
 name = "is_sorted"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,7 +245,7 @@ dependencies = [
  "koto_parser",
  "thiserror",
  "tokio",
- "tower-lsp",
+ "tower-lsp-server",
  "tracing-subscriber",
 ]
 
@@ -473,12 +308,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
-name = "litemap"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
-
-[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,15 +325,15 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "lsp-types"
-version = "0.94.1"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
+checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
 dependencies = [
  "bitflags 1.3.2",
+ "fluent-uri",
  "serde",
  "serde_json",
  "serde_repr",
- "url",
 ]
 
 [[package]]
@@ -585,32 +414,6 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets",
-]
-
-[[package]]
-name = "percent-encoding"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
-
-[[package]]
-name = "pin-project"
-version = "1.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -763,12 +566,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
 name = "syn"
 version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -780,15 +577,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.13.1"
+name = "sync_wrapper"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "thiserror"
@@ -818,16 +610,6 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
-]
-
-[[package]]
-name = "tinystr"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
-dependencies = [
- "displaydoc",
- "zerovec",
 ]
 
 [[package]]
@@ -874,14 +656,14 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.13"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "pin-project",
  "pin-project-lite",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
 ]
@@ -893,13 +675,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
-name = "tower-lsp"
-version = "0.20.0"
+name = "tower-lsp-server"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ba052b54a6627628d9b3c34c176e7eda8359b7da9acd497b9f20998d118508"
+checksum = "5fade4c658b63d11b623ddfa80821901e943a2923a010ae4a038661de42bd377"
 dependencies = [
- "async-trait",
- "auto_impl",
  "bytes",
  "dashmap",
  "futures",
@@ -911,19 +691,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tower",
- "tower-lsp-macros",
  "tracing",
-]
-
-[[package]]
-name = "tower-lsp-macros"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1012,30 +780,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "url"
-version = "2.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
- "serde",
-]
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "valuable"
@@ -1143,82 +887,3 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
-name = "writeable"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
-name = "yoke"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
-dependencies = [
- "serde",
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0.82"
 is_sorted = "0.1.1"
 thiserror = "2"
 tokio = { version = "1.37.0", features = ["full"] }
-tower-lsp = "0.20.0"
+tower-lsp-server = "0.21.1"
 tracing-subscriber = "0.3.18"
 
 [dependencies.koto_bytecode]

--- a/src/info_cache.rs
+++ b/src/info_cache.rs
@@ -1,6 +1,6 @@
 use crate::source_info::SourceInfo;
 use std::{collections::HashMap, sync::Arc, time::SystemTime};
-use tower_lsp::lsp_types::Url;
+use tower_lsp_server::lsp_types::Uri;
 
 /// A cache of analyzed sources
 ///
@@ -8,11 +8,11 @@ use tower_lsp::lsp_types::Url;
 /// which are then added to the cache to prevent unnecessary reanalysis.
 #[derive(Default, Debug)]
 pub struct InfoCache {
-    entries: HashMap<Arc<Url>, Info>,
+    entries: HashMap<Arc<Uri>, Info>,
 }
 
 impl InfoCache {
-    pub fn insert(&mut self, url: Arc<Url>, version: Version, info: SourceInfo) {
+    pub fn insert(&mut self, url: Arc<Uri>, version: Version, info: SourceInfo) {
         self.entries.insert(
             url,
             Info {
@@ -22,11 +22,11 @@ impl InfoCache {
         );
     }
 
-    pub fn get(&self, url: &Url) -> Option<Arc<SourceInfo>> {
+    pub fn get(&self, url: &Uri) -> Option<Arc<SourceInfo>> {
         self.entries.get(url).map(|info| info.info.clone())
     }
 
-    pub fn get_versioned(&self, url: &Url, version: Version) -> Option<Arc<SourceInfo>> {
+    pub fn get_versioned(&self, url: &Uri, version: Version) -> Option<Arc<SourceInfo>> {
         match self.entries.get(url) {
             Some(info) if info.version == version => Some(info.info.clone()),
             _ => None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ mod source_info;
 mod utils;
 
 use crate::server::KotoServer;
-use tower_lsp::{LspService, Server};
+use tower_lsp_server::{LspService, Server};
 
 #[tokio::main]
 async fn main() {

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,9 +4,9 @@ use crate::utils::{default, koto_span_to_lsp_range};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use tower_lsp::jsonrpc::{Error, Result};
-use tower_lsp::lsp_types::*;
-use tower_lsp::{Client, LanguageServer};
+use tower_lsp_server::jsonrpc::{Error, Result};
+use tower_lsp_server::lsp_types::*;
+use tower_lsp_server::{Client, LanguageServer};
 
 pub struct KotoServer {
     client: Client,
@@ -21,7 +21,7 @@ impl KotoServer {
         }
     }
 
-    async fn compile(&self, script: &str, uri: Url, version: i32) {
+    async fn compile(&self, script: &str, uri: Uri, version: i32) {
         if self
             .source_info
             .lock()
@@ -62,7 +62,6 @@ impl KotoServer {
     }
 }
 
-#[tower_lsp::async_trait]
 impl LanguageServer for KotoServer {
     async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
         Ok(InitializeResult {

--- a/src/source_info.rs
+++ b/src/source_info.rs
@@ -5,7 +5,10 @@ use koto_parser::{
 };
 use std::{cmp::Ordering, fs, sync::Arc};
 use thiserror::Error;
-use tower_lsp::lsp_types::{DocumentSymbol, Position, Range, SymbolKind, Url};
+use tower_lsp_server::{
+    UriExt,
+    lsp_types::{DocumentSymbol, Position, Range, SymbolKind, Uri},
+};
 
 use crate::{
     info_cache::InfoCache,
@@ -43,7 +46,7 @@ pub struct SourceInfo {
 
 impl SourceInfo {
     /// Returns a [SourceInfo] containing the result of analyzing the given script
-    pub fn new(script: &str, uri: Arc<Url>, info_cache: &mut InfoCache) -> Self {
+    pub fn new(script: &str, uri: Arc<Uri>, info_cache: &mut InfoCache) -> Self {
         let mut error = None;
         let ast = match Parser::parse(script) {
             Ok(ast) => ast,
@@ -107,12 +110,12 @@ impl SourceInfo {
 /// A location in a source file, identified by [Url] and [Range]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Location {
-    pub uri: Arc<Url>,
+    pub uri: Arc<Uri>,
     pub range: Range,
 }
 
 impl Location {
-    fn new(uri: Arc<Url>, span: Span) -> Self {
+    fn new(uri: Arc<Uri>, span: Span) -> Self {
         Self {
             uri,
             range: koto_span_to_lsp_range(span),
@@ -120,7 +123,7 @@ impl Location {
     }
 }
 
-impl From<Location> for tower_lsp::lsp_types::Location {
+impl From<Location> for tower_lsp_server::lsp_types::Location {
     fn from(value: Location) -> Self {
         Self {
             uri: value.uri.as_ref().clone(),
@@ -226,7 +229,7 @@ pub struct Reference {
 
 struct SourceInfoBuilder<'i> {
     // The uri of the file that is being scanned
-    uri: Arc<Url>,
+    uri: Arc<Uri>,
     // A cache that is used when importing modules
     #[allow(unused)]
     info_cache: &'i mut InfoCache,
@@ -244,7 +247,7 @@ struct SourceInfoBuilder<'i> {
 }
 
 impl<'i> SourceInfoBuilder<'i> {
-    fn from_ast(ast: &Ast, uri: Arc<Url>, info_cache: &'i mut InfoCache) -> Self {
+    fn from_ast(ast: &Ast, uri: Arc<Uri>, info_cache: &'i mut InfoCache) -> Self {
         let mut result = Self {
             uri,
             info_cache,
@@ -654,8 +657,10 @@ impl<'i> SourceInfoBuilder<'i> {
         }
     }
 
-    fn analyze_module(&mut self, url: Arc<Url>) {
-        let Ok(path) = url.to_file_path() else { return };
+    fn analyze_module(&mut self, url: Arc<Uri>) {
+        let Some(path) = url.to_file_path() else {
+            return;
+        };
         let Ok(metadata) = fs::metadata(&path) else {
             return;
         };
@@ -808,14 +813,14 @@ impl<'i> SourceInfoBuilder<'i> {
         });
     }
 
-    fn find_module(&self, name: &str) -> Option<Arc<Url>> {
-        if let Ok(script_path_buf) = self.uri.to_file_path() {
+    fn find_module(&self, name: &str) -> Option<Arc<Uri>> {
+        if let Some(script_path_buf) = self.uri.to_file_path() {
             // find modules at directory of current script
             let script_path = script_path_buf.parent();
             let Ok(path) = koto_bytecode::find_module(name, script_path) else {
                 return None;
             };
-            let Ok(url) = Url::from_file_path(path) else {
+            let Some(url) = Uri::from_file_path(path) else {
                 return None;
             };
             Some(Arc::new(url))
@@ -940,7 +945,8 @@ fn node_symbol_kind(node: &Node) -> SymbolKind {
 mod test {
     use super::*;
     use anyhow::Result;
-    use tower_lsp::lsp_types::Position;
+    use std::str::FromStr;
+    use tower_lsp_server::lsp_types::Position;
 
     fn position(line: u32, character: u32) -> Position {
         Position { line, character }
@@ -953,8 +959,8 @@ mod test {
         }
     }
 
-    fn test_uri() -> Arc<Url> {
-        Arc::new(Url::parse("file:///test.koto").unwrap())
+    fn test_uri() -> Arc<Uri> {
+        Arc::new(Uri::from_str("file:///test.koto").unwrap())
     }
 
     mod goto_definition {
@@ -1284,7 +1290,7 @@ x = |y| y.baz = bar
     }
 
     mod top_level_definitions {
-        use tower_lsp::lsp_types::SymbolKind;
+        use tower_lsp_server::lsp_types::SymbolKind;
 
         use super::*;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-use tower_lsp::lsp_types::{Position, Range};
+use tower_lsp_server::lsp_types::{Position, Range};
 
 pub fn koto_span_to_lsp_range(span: koto_parser::Span) -> Range {
     Range {


### PR DESCRIPTION
From unmaintained `tower_lsp 0.20.0` to maintained community fork (with bugfixes, upgraded dependencies, etc.) `tower_lsp_server 0.21.1`. 